### PR TITLE
Bugfix -> the function needed in parent seems to be "remove", not "de…

### DIFF
--- a/crisp_api/resources/website.py
+++ b/crisp_api/resources/website.py
@@ -70,7 +70,7 @@ class WebsiteResource(object):
     return self.parent.get(self.__url_conversation(website_id, session_id, ""))
 
   def remove_conversation(self, website_id, session_id):
-    return self.parent.delete(self.__url_conversation(website_id, session_id, ""))
+    return self.parent.remove(self.__url_conversation(website_id, session_id, ""))
 
   def initiate_conversation_with_existing_session(self, website_id, session_id):
     return self.parent.post(self.__url_conversation(website_id, session_id, "/initiate"))


### PR DESCRIPTION
…lete".

I was getting this error:
def remove_conversation(self, website_id, session_id):
>     return self.parent.delete(self.__url_conversation(website_id, session_id, ""))
E     AttributeError: 'Crisp' object has no attribute 'delete'

Crisp does seem to have an attribute called remove that has the right behaviour. This may just be a naming error...?