### PR TITLE
Added encoding=utf-8 to file open() in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url='https://github.com/crisp-im/python-crisp-api',
     license='MIT - http://opensource.org/licenses/mit-license.php',
     description='Crisp API Python.',
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding='utf-8').read(),
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Explicit encoding in setup.py fixes pip installation issues on Windows.