### PR TITLE
Added get_a_message_in_conversation method

### DIFF
--- a/crisp_api/resources/website.py
+++ b/crisp_api/resources/website.py
@@ -118,6 +118,9 @@ class WebsiteResource(object):
   def get_messages_in_conversation(self, website_id, session_id, query):
     return self.parent.get(self.__url_conversation(website_id, session_id, "/messages"), query)
 
+  def get_a_message_in_conversation(self, website_id, session_id, fingerprint):
+    return self.parent.get(self.__url_conversation(website_id, session_id, f"/message/{fingerprint}"))
+
   def send_message_in_conversation(self, website_id, session_id, data):
     return self.parent.post(self.__url_conversation(website_id, session_id, "/message"), data)
 


### PR DESCRIPTION
Added get_a_message_in_conversation method that implements [https://docs.crisp.chat/references/rest-api/v1/#get-a-message-in-conversation](url)